### PR TITLE
Implement DataSpace editor component

### DIFF
--- a/packages/legend-extension-dsl-data-space-studio/src/components/DSL_DataSpace_LegendStudioApplicationPlugin.tsx
+++ b/packages/legend-extension-dsl-data-space-studio/src/components/DSL_DataSpace_LegendStudioApplicationPlugin.tsx
@@ -223,8 +223,8 @@ export class DSL_DataSpace_LegendStudioApplicationPlugin
         element: PackageableElement,
       ): ElementEditorState | undefined => {
         if (element instanceof DataSpace) {
-          return new UnsupportedElementEditorState(editorStore, element);
-          // return new DataSpaceEditorState(editorStore, element);
+          // return new UnsupportedElementEditorState(editorStore, element);
+          return new DataSpaceEditorState(editorStore, element);
         }
         return undefined;
       },

--- a/packages/legend-extension-dsl-data-space-studio/src/components/DataSpaceEditor.tsx
+++ b/packages/legend-extension-dsl-data-space-studio/src/components/DataSpaceEditor.tsx
@@ -16,11 +16,38 @@
 
 import { observer } from 'mobx-react-lite';
 import { useEditorStore } from '@finos/legend-application-studio';
-import { PanelFormTextField } from '@finos/legend-art';
+import {
+  Panel,
+  PanelContent,
+  PanelHeader,
+  PanelFormTextField,
+  PanelFormListItems,
+  PanelFormSection,
+  CustomSelectorInput,
+} from '@finos/legend-art';
+import {
+  DataSpaceExecutionContext,
+  DataSpaceSupportCombinedInfo,
+  DataSpaceSupportEmail,
+  DataSpacePackageableElementExecutable,
+} from '@finos/legend-extension-dsl-data-space/graph';
 import { DataSpaceEditorState } from '../stores/DataSpaceEditorState.js';
 import {
-  set_description,
   set_title,
+  set_description,
+  set_defaultExecutionContext,
+  add_executionContext,
+  remove_executionContext,
+  add_element,
+  remove_element,
+  add_executable,
+  remove_executable,
+  add_diagram,
+  remove_diagram,
+  set_executionContext_name,
+  set_executionContext_title,
+  set_executionContext_description,
+  set_supportInfo,
 } from '../stores/studio/DSL_DataSpace_GraphModifierHelper.js';
 
 export const DataSpaceEditor = observer(() => {
@@ -31,6 +58,7 @@ export const DataSpaceEditor = observer(() => {
 
   const formElement = formEditorState.dataSpace;
 
+  // Basic properties handlers
   const handleTitleChange = (value: string | undefined): void => {
     set_title(formElement, value);
   };
@@ -39,29 +67,484 @@ export const DataSpaceEditor = observer(() => {
     set_description(formElement, value);
   };
 
+  // ExecutionContexts handlers
+  const handleAddExecutionContext = (): void => {
+    const newExecutionContext =
+      new formEditorState.dataSpaceElementBuilder.DataSpaceExecutionContext();
+    newExecutionContext.name = `context_${formElement.executionContexts.length + 1}`;
+    add_executionContext(formElement, newExecutionContext);
+  };
+
+  const handleRemoveExecutionContext = (index: number): void => {
+    remove_executionContext(formElement, index);
+  };
+
+  const handleExecutionContextNameChange = (
+    index: number,
+    value: string,
+  ): void => {
+    const context = formElement.executionContexts[index];
+    if (context) {
+      set_executionContext_name(context, value);
+    }
+  };
+
+  const handleExecutionContextTitleChange = (
+    index: number,
+    value: string | undefined,
+  ): void => {
+    const context = formElement.executionContexts[index];
+    if (context) {
+      set_executionContext_title(context, value);
+    }
+  };
+
+  const handleExecutionContextDescriptionChange = (
+    index: number,
+    value: string | undefined,
+  ): void => {
+    const context = formElement.executionContexts[index];
+    if (context) {
+      set_executionContext_description(context, value);
+    }
+  };
+
+  // DefaultExecutionContext handler
+  const handleDefaultExecutionContextChange = (option: {
+    value: unknown;
+  }): void => {
+    if (
+      option &&
+      typeof option === 'object' &&
+      'value' in option &&
+      option.value &&
+      typeof option.value === 'object'
+    ) {
+      const context = option.value as DataSpaceExecutionContext;
+      set_defaultExecutionContext(formElement, context);
+    }
+  };
+
+  // Elements handlers
+  const handleAddElement = (): void => {
+    const newElement =
+      new formEditorState.dataSpaceElementBuilder.DataSpaceElementPointer();
+    add_element(formElement, newElement);
+  };
+
+  const handleRemoveElement = (index: number): void => {
+    remove_element(formElement, index);
+  };
+
+  // Executables handlers
+  const handleAddExecutable = (): void => {
+    const newExecutable =
+      new formEditorState.dataSpaceElementBuilder.DataSpacePackageableElementExecutable();
+    newExecutable.title = `Executable ${formElement.executables?.length ?? 0 + 1}`;
+    add_executable(formElement, newExecutable);
+  };
+
+  const handleRemoveExecutable = (index: number): void => {
+    remove_executable(formElement, index);
+  };
+
+  // Diagrams handlers
+  const handleAddDiagram = (): void => {
+    const newDiagram =
+      new formEditorState.dataSpaceElementBuilder.DataSpaceDiagram();
+    newDiagram.title = `Diagram ${formElement.diagrams?.length ?? 0 + 1}`;
+    add_diagram(formElement, newDiagram);
+  };
+
+  const handleRemoveDiagram = (index: number): void => {
+    remove_diagram(formElement, index);
+  };
+
+  // SupportInfo handlers
+  const handleSupportInfoTypeChange = (option: { value: unknown }): void => {
+    if (!option || typeof option !== 'object' || !('value' in option)) {
+      return;
+    }
+    const type = option.value as string;
+    if (type === 'email') {
+      const supportInfo =
+        new formEditorState.dataSpaceElementBuilder.DataSpaceSupportEmail();
+      set_supportInfo(formElement, supportInfo);
+    } else if (type === 'combined') {
+      const supportInfo =
+        new formEditorState.dataSpaceElementBuilder.DataSpaceSupportCombinedInfo();
+      set_supportInfo(formElement, supportInfo);
+    } else {
+      set_supportInfo(formElement, undefined);
+    }
+  };
+
   return (
-    <div className="dataSpace-editor panel dataSpace-editor--dark">
-      <div className="panel__content__form">
-        <div className="panel__content__form__section">
-          <PanelFormTextField
-            name="Data Product Title"
-            value={formElement.title ?? ''}
-            prompt="Data Product title is the user facing name for the Data Product. It used in downstream applications as the default identifier for this Data Product. When not provided, the DataProduct name property is used"
-            update={handleTitleChange}
-            placeholder="Enter title"
-          />
+    <Panel className="dataSpace-editor panel dataSpace-editor--dark">
+      <PanelHeader title="Data Space Editor" />
+      <PanelContent>
+        <div className="panel__content__form">
+          {/* Basic Properties Section */}
+          <PanelFormSection>
+            <PanelFormTextField
+              name="Data Space Title"
+              value={formElement.title ?? ''}
+              prompt="Data Space title is the user facing name for the Data Space. It is used in downstream applications as the default identifier for this Data Space. When not provided, the DataSpace name property is used."
+              update={handleTitleChange}
+              placeholder="Enter title"
+            />
+          </PanelFormSection>
+
+          <PanelFormSection>
+            <PanelFormTextField
+              name="Data Space Description"
+              value={formElement.description ?? ''}
+              prompt="Provide a description for this Data Space."
+              update={handleDescriptionChange}
+              placeholder="Enter description"
+            />
+          </PanelFormSection>
+
+          {/* Execution Contexts Section */}
+          <PanelFormListItems title="Execution Contexts">
+            {formElement.executionContexts.map((context, index) => (
+              <div
+                key={index}
+                className="panel__content__form__section__list__item"
+              >
+                <PanelFormTextField
+                  name={`Context ${index + 1} Name`}
+                  value={context.name}
+                  update={(value) =>
+                    handleExecutionContextNameChange(index, value ?? '')
+                  }
+                  placeholder="Enter name"
+                />
+                <PanelFormTextField
+                  name={`Context ${index + 1} Title`}
+                  value={context.title ?? ''}
+                  update={(value) =>
+                    handleExecutionContextTitleChange(index, value)
+                  }
+                  placeholder="Enter title"
+                />
+                <PanelFormTextField
+                  name={`Context ${index + 1} Description`}
+                  value={context.description ?? ''}
+                  update={(value) =>
+                    handleExecutionContextDescriptionChange(index, value)
+                  }
+                  placeholder="Enter description"
+                />
+                <button
+                  className="panel__content__form__section__button"
+                  onClick={() => handleRemoveExecutionContext(index)}
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+            <button
+              className="panel__content__form__section__button"
+              onClick={handleAddExecutionContext}
+            >
+              Add Execution Context
+            </button>
+          </PanelFormListItems>
+
+          {/* Default Execution Context Section */}
+          <PanelFormSection>
+            <div className="panel__content__form__section__header__label">
+              Default Execution Context
+            </div>
+            <div className="panel__content__form__section__header__prompt">
+              Select the default execution context for this Data Space.
+            </div>
+            <CustomSelectorInput
+              options={formElement.executionContexts.map((context) => ({
+                label: context.name,
+                value: context,
+              }))}
+              onChange={(option: { label: string; value: unknown }) =>
+                handleDefaultExecutionContextChange(option)
+              }
+              value={{
+                label: formElement.defaultExecutionContext.name,
+                value: formElement.defaultExecutionContext,
+              }}
+            />
+          </PanelFormSection>
+
+          {/* Elements Section */}
+          <PanelFormListItems title="Elements">
+            {formElement.elements?.map((element, index) => (
+              <div
+                key={index}
+                className="panel__content__form__section__list__item"
+              >
+                <div className="panel__content__form__section__header__label">
+                  Element {index + 1}
+                </div>
+                <div className="panel__content__form__section__checkbox">
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={element.exclude ?? false}
+                      onChange={(e) => {
+                        if (
+                          formElement.elements &&
+                          formElement.elements[index]
+                        ) {
+                          formElement.elements[index].exclude =
+                            e.target.checked;
+                        }
+                      }}
+                    />
+                    Exclude
+                  </label>
+                </div>
+                <button
+                  className="panel__content__form__section__button"
+                  onClick={() => handleRemoveElement(index)}
+                >
+                  Remove
+                </button>
+              </div>
+            )) ?? <div>No elements defined</div>}
+            <button
+              className="panel__content__form__section__button"
+              onClick={handleAddElement}
+            >
+              Add Element
+            </button>
+          </PanelFormListItems>
+
+          {/* Executables Section */}
+          <PanelFormListItems title="Executables">
+            {formElement.executables?.map((executable, index) => (
+              <div
+                key={index}
+                className="panel__content__form__section__list__item"
+              >
+                <PanelFormTextField
+                  name={`Executable ${index + 1} Title`}
+                  value={executable.title}
+                  update={(value) => {
+                    if (
+                      formElement.executables &&
+                      formElement.executables[index]
+                    ) {
+                      formElement.executables[index].title = value ?? '';
+                    }
+                  }}
+                  placeholder="Enter title"
+                />
+                <PanelFormTextField
+                  name={`Executable ${index + 1} Description`}
+                  value={executable.description ?? ''}
+                  update={(value) => {
+                    if (
+                      formElement.executables &&
+                      formElement.executables[index]
+                    ) {
+                      formElement.executables[index].description = value;
+                    }
+                  }}
+                  placeholder="Enter description"
+                />
+                <button
+                  className="panel__content__form__section__button"
+                  onClick={() => handleRemoveExecutable(index)}
+                >
+                  Remove
+                </button>
+              </div>
+            )) ?? <div>No executables defined</div>}
+            <button
+              className="panel__content__form__section__button"
+              onClick={handleAddExecutable}
+            >
+              Add Executable
+            </button>
+          </PanelFormListItems>
+
+          {/* Diagrams Section */}
+          <PanelFormListItems title="Diagrams">
+            {formElement.diagrams?.map((diagram, index) => (
+              <div
+                key={index}
+                className="panel__content__form__section__list__item"
+              >
+                <PanelFormTextField
+                  name={`Diagram ${index + 1} Title`}
+                  value={diagram.title}
+                  update={(value) => {
+                    if (formElement.diagrams && formElement.diagrams[index]) {
+                      formElement.diagrams[index].title = value ?? '';
+                    }
+                  }}
+                  placeholder="Enter title"
+                />
+                <PanelFormTextField
+                  name={`Diagram ${index + 1} Description`}
+                  value={diagram.description ?? ''}
+                  update={(value) => {
+                    if (formElement.diagrams && formElement.diagrams[index]) {
+                      formElement.diagrams[index].description = value;
+                    }
+                  }}
+                  placeholder="Enter description"
+                />
+                <button
+                  className="panel__content__form__section__button"
+                  onClick={() => handleRemoveDiagram(index)}
+                >
+                  Remove
+                </button>
+              </div>
+            )) ?? <div>No diagrams defined</div>}
+            <button
+              className="panel__content__form__section__button"
+              onClick={handleAddDiagram}
+            >
+              Add Diagram
+            </button>
+          </PanelFormListItems>
+
+          {/* Support Info Section */}
+          <PanelFormListItems title="Support Information">
+            <div className="panel__content__form__section__header__prompt">
+              Configure support information for this Data Space.
+            </div>
+            <CustomSelectorInput
+              options={[
+                { label: 'None', value: 'none' },
+                { label: 'Email', value: 'email' },
+                { label: 'Combined', value: 'combined' },
+              ]}
+              onChange={(option: { label: string; value: unknown }) =>
+                handleSupportInfoTypeChange(option)
+              }
+              value={{
+                label: formElement.supportInfo
+                  ? formEditorState.dataSpaceElementBuilder.isDataSpaceSupportEmail(
+                      formElement.supportInfo,
+                    )
+                    ? 'Email'
+                    : 'Combined'
+                  : 'None',
+                value: formElement.supportInfo
+                  ? formEditorState.dataSpaceElementBuilder.isDataSpaceSupportEmail(
+                      formElement.supportInfo,
+                    )
+                    ? 'email'
+                    : 'combined'
+                  : 'none',
+              }}
+            />
+            {formElement.supportInfo && (
+              <div className="panel__content__form__section__list__item">
+                {/* Support Info properties editing UI based on type */}
+                {formEditorState.dataSpaceElementBuilder.isDataSpaceSupportEmail(
+                  formElement.supportInfo,
+                ) ? (
+                  <PanelFormTextField
+                    name="Email Address"
+                    value={formElement.supportInfo.address}
+                    update={(value) => {
+                      if (
+                        formEditorState.dataSpaceElementBuilder.isDataSpaceSupportEmail(
+                          formElement.supportInfo,
+                        )
+                      ) {
+                        formElement.supportInfo.address = value ?? '';
+                      }
+                    }}
+                    placeholder="Enter email address"
+                  />
+                ) : (
+                  <div>
+                    {/* Combined support info editing UI */}
+                    <PanelFormTextField
+                      name="Website"
+                      value={
+                        formEditorState.dataSpaceElementBuilder.isDataSpaceSupportCombinedInfo(
+                          formElement.supportInfo,
+                        )
+                          ? (formElement.supportInfo.website ?? '')
+                          : ''
+                      }
+                      update={(value) => {
+                        if (
+                          formElement.supportInfo &&
+                          formEditorState.dataSpaceElementBuilder.isDataSpaceSupportCombinedInfo(
+                            formElement.supportInfo,
+                          )
+                        ) {
+                          formElement.supportInfo.website = value;
+                        }
+                      }}
+                      placeholder="Enter website URL"
+                    />
+                    <PanelFormTextField
+                      name="FAQ URL"
+                      value={
+                        formEditorState.dataSpaceElementBuilder.isDataSpaceSupportCombinedInfo(
+                          formElement.supportInfo,
+                        )
+                          ? (formElement.supportInfo.faqUrl ?? '')
+                          : ''
+                      }
+                      update={(value) => {
+                        if (
+                          formElement.supportInfo &&
+                          formEditorState.dataSpaceElementBuilder.isDataSpaceSupportCombinedInfo(
+                            formElement.supportInfo,
+                          )
+                        ) {
+                          formElement.supportInfo.faqUrl = value;
+                        }
+                      }}
+                      placeholder="Enter FAQ URL"
+                    />
+                    <PanelFormTextField
+                      name="Support URL"
+                      value={
+                        formEditorState.dataSpaceElementBuilder.isDataSpaceSupportCombinedInfo(
+                          formElement.supportInfo,
+                        )
+                          ? (formElement.supportInfo.supportUrl ?? '')
+                          : ''
+                      }
+                      update={(value) => {
+                        if (
+                          formElement.supportInfo &&
+                          formEditorState.dataSpaceElementBuilder.isDataSpaceSupportCombinedInfo(
+                            formElement.supportInfo,
+                          )
+                        ) {
+                          formElement.supportInfo.supportUrl = value;
+                        }
+                      }}
+                      placeholder="Enter support URL"
+                    />
+                    <PanelFormTextField
+                      name="Documentation URL"
+                      value={formElement.supportInfo.documentationUrl ?? ''}
+                      update={(value) => {
+                        if (formElement.supportInfo) {
+                          formElement.supportInfo.documentationUrl = value;
+                        }
+                      }}
+                      placeholder="Enter documentation URL"
+                    />
+                  </div>
+                )}
+              </div>
+            )}
+          </PanelFormListItems>
         </div>
-      </div>
-      <div className="panel__content__form">
-        <div className="panel__content__form__section">
-          <PanelFormTextField
-            name="Data Product Description"
-            value={formElement.description ?? ''}
-            update={handleDescriptionChange}
-            placeholder="Enter Description"
-          />
-        </div>
-      </div>
-    </div>
+      </PanelContent>
+    </Panel>
   );
 });

--- a/packages/legend-extension-dsl-data-space-studio/src/stores/DataSpaceEditorState.ts
+++ b/packages/legend-extension-dsl-data-space-studio/src/stores/DataSpaceEditorState.ts
@@ -20,10 +20,36 @@ import {
   ElementEditorState,
 } from '@finos/legend-application-studio';
 import type { PackageableElement } from '@finos/legend-graph';
-import { DataSpace } from '@finos/legend-extension-dsl-data-space/graph';
-import { guaranteeType } from '@finos/legend-shared';
+import {
+  DataSpace,
+  DataSpaceExecutionContext,
+  DataSpaceElementPointer,
+  DataSpaceDiagram,
+  DataSpaceSupportEmail,
+  DataSpaceSupportCombinedInfo,
+  DataSpacePackageableElementExecutable,
+} from '@finos/legend-extension-dsl-data-space/graph';
+import { guaranteeType, uuid } from '@finos/legend-shared';
 
 export class DataSpaceEditorState extends ElementEditorState {
+  override readonly uuid = uuid();
+
+  readonly dataSpaceElementBuilder = {
+    DataSpaceExecutionContext: DataSpaceExecutionContext,
+    DataSpaceElementPointer: DataSpaceElementPointer,
+    DataSpaceDiagram: DataSpaceDiagram,
+    DataSpaceSupportEmail: DataSpaceSupportEmail,
+    DataSpaceSupportCombinedInfo: DataSpaceSupportCombinedInfo,
+    DataSpacePackageableElementExecutable:
+      DataSpacePackageableElementExecutable,
+    isDataSpaceSupportEmail: (obj: unknown): obj is DataSpaceSupportEmail =>
+      obj instanceof DataSpaceSupportEmail,
+    isDataSpaceSupportCombinedInfo: (
+      obj: unknown,
+    ): obj is DataSpaceSupportCombinedInfo =>
+      obj instanceof DataSpaceSupportCombinedInfo,
+  };
+
   constructor(editorStore: EditorStore, element: PackageableElement) {
     super(editorStore, element);
 
@@ -37,7 +63,7 @@ export class DataSpaceEditorState extends ElementEditorState {
     return guaranteeType(
       this.element,
       DataSpace,
-      'Element inside text element editor state must be a text element',
+      'Element inside DataSpace editor state must be a DataSpace element',
     );
   }
 

--- a/packages/legend-extension-dsl-data-space-studio/src/stores/studio/DSL_DataSpace_GraphModifierHelper.ts
+++ b/packages/legend-extension-dsl-data-space-studio/src/stores/studio/DSL_DataSpace_GraphModifierHelper.ts
@@ -15,8 +15,22 @@
  */
 
 import { action } from 'mobx';
-import type { DataSpace } from '@finos/legend-extension-dsl-data-space/graph';
+import type {
+  DataSpace,
+  DataSpaceExecutionContext,
+  DataSpaceElementPointer,
+  DataSpaceExecutable,
+  DataSpaceDiagram,
+  DataSpaceSupportInfo,
+} from '@finos/legend-extension-dsl-data-space/graph';
+import type {
+  PackageableElementReference,
+  Mapping,
+  PackageableRuntime,
+  DataElementReference,
+} from '@finos/legend-graph';
 
+// Basic properties
 export const set_title = action(
   (dataSpace: DataSpace, type: string | undefined): void => {
     dataSpace.title = type;
@@ -26,5 +40,173 @@ export const set_title = action(
 export const set_description = action(
   (dataSpace: DataSpace, content: string | undefined): void => {
     dataSpace.description = content;
+  },
+);
+
+// Array properties
+export const set_executionContexts = action(
+  (
+    dataSpace: DataSpace,
+    executionContexts: DataSpaceExecutionContext[],
+  ): void => {
+    dataSpace.executionContexts = executionContexts;
+  },
+);
+
+export const set_defaultExecutionContext = action(
+  (
+    dataSpace: DataSpace,
+    defaultExecutionContext: DataSpaceExecutionContext,
+  ): void => {
+    dataSpace.defaultExecutionContext = defaultExecutionContext;
+  },
+);
+
+export const set_elements = action(
+  (
+    dataSpace: DataSpace,
+    elements: DataSpaceElementPointer[] | undefined,
+  ): void => {
+    dataSpace.elements = elements;
+  },
+);
+
+export const set_executables = action(
+  (
+    dataSpace: DataSpace,
+    executables: DataSpaceExecutable[] | undefined,
+  ): void => {
+    dataSpace.executables = executables;
+  },
+);
+
+export const set_diagrams = action(
+  (dataSpace: DataSpace, diagrams: DataSpaceDiagram[] | undefined): void => {
+    dataSpace.diagrams = diagrams;
+  },
+);
+
+export const set_supportInfo = action(
+  (
+    dataSpace: DataSpace,
+    supportInfo: DataSpaceSupportInfo | undefined,
+  ): void => {
+    dataSpace.supportInfo = supportInfo;
+  },
+);
+
+// Array item management
+export const add_executionContext = action(
+  (dataSpace: DataSpace, executionContext: DataSpaceExecutionContext): void => {
+    dataSpace.executionContexts.push(executionContext);
+  },
+);
+
+export const remove_executionContext = action(
+  (dataSpace: DataSpace, index: number): void => {
+    dataSpace.executionContexts.splice(index, 1);
+  },
+);
+
+export const add_element = action(
+  (dataSpace: DataSpace, element: DataSpaceElementPointer): void => {
+    if (!dataSpace.elements) {
+      dataSpace.elements = [];
+    }
+    dataSpace.elements.push(element);
+  },
+);
+
+export const remove_element = action(
+  (dataSpace: DataSpace, index: number): void => {
+    if (dataSpace.elements) {
+      dataSpace.elements.splice(index, 1);
+    }
+  },
+);
+
+export const add_executable = action(
+  (dataSpace: DataSpace, executable: DataSpaceExecutable): void => {
+    if (!dataSpace.executables) {
+      dataSpace.executables = [];
+    }
+    dataSpace.executables.push(executable);
+  },
+);
+
+export const remove_executable = action(
+  (dataSpace: DataSpace, index: number): void => {
+    if (dataSpace.executables) {
+      dataSpace.executables.splice(index, 1);
+    }
+  },
+);
+
+export const add_diagram = action(
+  (dataSpace: DataSpace, diagram: DataSpaceDiagram): void => {
+    if (!dataSpace.diagrams) {
+      dataSpace.diagrams = [];
+    }
+    dataSpace.diagrams.push(diagram);
+  },
+);
+
+export const remove_diagram = action(
+  (dataSpace: DataSpace, index: number): void => {
+    if (dataSpace.diagrams) {
+      dataSpace.diagrams.splice(index, 1);
+    }
+  },
+);
+
+// Nested object properties
+export const set_executionContext_name = action(
+  (executionContext: DataSpaceExecutionContext, name: string): void => {
+    executionContext.name = name;
+  },
+);
+
+export const set_executionContext_title = action(
+  (
+    executionContext: DataSpaceExecutionContext,
+    title: string | undefined,
+  ): void => {
+    executionContext.title = title;
+  },
+);
+
+export const set_executionContext_description = action(
+  (
+    executionContext: DataSpaceExecutionContext,
+    description: string | undefined,
+  ): void => {
+    executionContext.description = description;
+  },
+);
+
+export const set_executionContext_mapping = action(
+  (
+    executionContext: DataSpaceExecutionContext,
+    mapping: PackageableElementReference<Mapping>,
+  ): void => {
+    executionContext.mapping = mapping;
+  },
+);
+
+export const set_executionContext_defaultRuntime = action(
+  (
+    executionContext: DataSpaceExecutionContext,
+    defaultRuntime: PackageableElementReference<PackageableRuntime>,
+  ): void => {
+    executionContext.defaultRuntime = defaultRuntime;
+  },
+);
+
+export const set_executionContext_testData = action(
+  (
+    executionContext: DataSpaceExecutionContext,
+    testData: DataElementReference | undefined,
+  ): void => {
+    executionContext.testData = testData;
   },
 );


### PR DESCRIPTION
# Implement DataSpace Editor Component

This PR adds a comprehensive editor component for the DataSpace class, allowing users to visually edit all properties including:

- Basic properties (title, description)
- Execution contexts with their properties
- Default execution context selection
- Elements with exclude option
- Executables with title and description
- Diagrams with title and description
- Support information (Email or Combined types)

## Implementation Details

- Created a form-based editor in `DataSpaceEditor.tsx` following the ConnectionEditor pattern
- Added type-safe action methods in `DSL_DataSpace_GraphModifierHelper.ts` for updating state
- Enhanced `DataSpaceEditorState.ts` with builder methods for creating and checking types
- Updated the plugin to use the new editor instead of the UnsupportedElementEditorState

Link to Devin run: https://app.devin.ai/sessions/05a5a240789941bb8e6b0158a5709426
Requested by: travis.stebbins@gs.com
